### PR TITLE
fix && batch training

### DIFF
--- a/constant_rate.m
+++ b/constant_rate.m
@@ -1,0 +1,3 @@
+function y = constant_rate(x)
+	y = 0.5;
+end

--- a/execute.m
+++ b/execute.m
@@ -4,7 +4,7 @@ function execute(nodes_per_layer,paths,g,g_der,learning_rate,b,err)
 
 	[trainning_set test_set] = get_trainning_set(paths);
 
-	learned_net = train_multilayer_network_online(net,trainning_set,err,g,g_der,learning_rate,b)
+	learned_net = train_multilayer_network_batch(net,trainning_set,err,g,g_der,learning_rate,b)
 
 	test(learned_net,test_set,g,b,size(nodes_per_layer)(2)-1);
 

--- a/init_xor.m
+++ b/init_xor.m
@@ -3,10 +3,10 @@ function init_xor
 g=@tanh_func;
 g_der=@tanh_func_derivate;
 b = 1;
-learning_rate = 0.05;
+learning_rate = @constant_rate;
 paths = 'test.txt';
 nodes_per_layer = [2,2,1]; 
-err = 10^-2;
+err = 10^-3;
 execute(nodes_per_layer,paths,g,g_der,learning_rate,b,err);
 
 

--- a/test.m
+++ b/test.m
@@ -3,12 +3,13 @@ function test(learned_net,test_set,g,b,layers_quantity)
 		expected_output = test_set(:,3);
 
 
-		layer_in = input
+		layer_in = input;
 		for m=1:layers_quantity
 			layer_out = g(b,([(ones(size(layer_in)(1),1)*(-1)) layer_in]*learned_net{m}));
 			V{m} = layer_out;
 			layer_in = layer_out;
 		end
-		
-		abs(layer_in-expected_output)
+		expected_output
+		layer_in
+		%abs(layer_in-expected_output)
 end

--- a/train_multilayer_network_batch.m
+++ b/train_multilayer_network_batch.m
@@ -1,0 +1,40 @@
+function ans_net = train_multilayer_network_online(net,patterns,err,g,g_der,learning_rate,b)
+
+	expected_output = patterns(:,3);
+	input = patterns(:,1:2);
+	patterns_quantity = size(input)(1);
+	layers_quantity = size(net)(2);
+
+	iteration = 1;
+
+	do 
+		printf('iteration: %d\n',iteration);
+		layer_in = input;
+		for m=1:layers_quantity
+			layer_out = g(b,([(ones(size(layer_in)(1),1)*(-1)) layer_in]*net{m}));
+			V{m} = layer_out; 
+			layer_in = layer_out;
+		end
+
+		delta{layers_quantity} = g_der(b,V{layers_quantity}).*(expected_output-V{layers_quantity});
+
+		for m=layers_quantity:-1:2
+			delta{m-1} = g_der(b,V{m-1}).*(delta{m}*(net{m}(2:end,:))');
+			net{m} = net{m} + learning_rate(iteration)*[  ones(size(V{m-1})(1),1).*(-1) V{m-1}]'*delta{m};
+		end
+
+		net{1} = net{1} + learning_rate(iteration)*[ ones(size(input)(1),1).*(-1) input]'*delta{1};
+
+
+
+		0.5*sum((expected_output-V{layers_quantity}).^2)
+		fflush(stdout);
+
+		iteration=iteration+1;
+
+	until (0.5*sum((expected_output-V{layers_quantity}).^2)/patterns_quantity < err)
+
+
+	ans_net = net;
+
+end

--- a/train_multilayer_network_online.m
+++ b/train_multilayer_network_online.m
@@ -1,6 +1,6 @@
 function ans_net = train_multilayer_network_online(net,patterns,err,g,g_der,learning_rate,b)
 
-	expected_output = patterns(:,2);
+	expected_output = patterns(:,3);
 	input = patterns(:,1:2);
 	patterns_quantity = size(input)(1);
 	layers_quantity = size(net)(2);


### PR DESCRIPTION
- Fix  in  "train_multilayer_network_online.m" the "expected_output" variable was bad assigned (it was assigned an input column of the dataset instead of the expected output of the dataset), therefore the network was being trained with wrong information.
- It has been added batch training.